### PR TITLE
[FIX] uncomment resetSystem in resetDB for normal execution

### DIFF
--- a/src/test/java/com/my/web/shop/TestRollOut.java
+++ b/src/test/java/com/my/web/shop/TestRollOut.java
@@ -37,7 +37,7 @@ public class TestRollOut {
         System.out.println("Provision system");
         ConfigValueHandler.PHASED_TEST_DETECT_ORDER.activate("true");
 
-        //Provision.resetSystem();
+        Provision.resetSystem();
         ShoppingBasket.loadPriceDB();
     }
 


### PR DESCRIPTION
Under normal execution, the `Provision.resetSystem();` should be executed to create the `products.properties` file.